### PR TITLE
Potential fix for code scanning alert no. 40: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/aurora-shell-build.yml
+++ b/.github/workflows/aurora-shell-build.yml
@@ -11,6 +11,9 @@ on:
   repository_dispatch:
     types: [trigger-aurora-build]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     name: Build & Verify
@@ -57,6 +60,9 @@ jobs:
     needs: build-and-test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/dev'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Get Version


### PR DESCRIPTION
Potential fix for [https://github.com/YashB-byte/aurora-shell/security/code-scanning/40](https://github.com/YashB-byte/aurora-shell/security/code-scanning/40)

Add explicit `permissions` to the workflow root as least-privilege defaults, then override per job where write access is actually required.

Best single approach for this file:
- Add at top level (after triggers, before `jobs`):  
  `permissions: { contents: read }` (YAML block form), which safely scopes `build-and-test`.
- Add job-level permissions for `create-pull-request` because that action needs to create/update PR branches and PRs:
  - `contents: write`
  - `pull-requests: write`
- Keep `publish-release` permissions as-is (`contents: write`), since release creation needs write access to repository contents/releases.

This preserves existing functionality while making token privileges explicit and minimal.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
